### PR TITLE
Implemented agreed changes for neuron morphology schema

### DIFF
--- a/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
+++ b/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
@@ -10,7 +10,8 @@
   "imports": [
     "https://neuroshapes.org/core/dataset",
     "https://neuroshapes.org/commons/quantitativevalue",
-    "https://neuroshapes.org/commons/brainlocation"
+    "https://neuroshapes.org/commons/brainlocation",
+    "https://neuroshapes.org/commons/typedlabeledontologyterm"
   ],
   "shapes": [
     {
@@ -27,118 +28,74 @@
         },
         {
           "property": [
-
             {
-              "path": "nsg:isRegisteredIn", // change the name, but all the Atlas data are already using isRegisterdIn...
+              "path": "nsg:isRegisteredIn",
               "class": "nsg:BrainAtlasSpatialReferenceSystem",
               "maxCount": 1
             },
-
-            {
-              "path": "nsg:brainLocation",
-              "name": "brain location",
-              "description": "Brain Location (brain region, atlas space).",
-              "node": "https://neuroshapes.org/commons/brainlocation/shapes/BrainLocationShape",
-              "minCount": 0,
-              "maxCount": 1
-            },
-
-
-            { // use types instead? Or taxonomy? (revise the set of types)
-              "path": "nsg:morphologyOrigin",
-              "name": "Morphology origin",
-              "description": "The kind of data or material a morphology was generated from.",
-              "in": [
-                "slice",
-                "volume",
-                "in-silico",
-                "other"
-              ],
-              "minCount": 1,
-              "maxCount": 1
-            },
-
             {
               "path": "nsg:somaNumberOfPoints",
               "name": "Soma number of points",
               "description": "Number of points involved in the modelisation of the soma",
               "datatype": "xsd:int",
-              "minCount": 0,
               "maxCount": 1
             },
-            
             {
-              "path": "nsg:basalDendriteFeature",
-              "name": "Basal dendrite feature",
-              "description": "Unopinionated metrics relative to the basal dendrites of this morphology",
-              "node": "this:NeuriteFeatures"
-            },
-
-
-            {
-              "path": "nsg:apicalDendriteFeature",
-              "name": "Apical dendrite feature",
-              "description": "Unopinionated metrics relative to the apical dendrites of this morphology",
-              "node": "this:NeuriteFeatures"
-            },
-
-            {
-              "path": "nsg:axonFeature",
-              "name": "Axon feature",
-              "description": "Unopinionated metrics relative to the axon of this morphology",
-              "node": "this:NeuriteFeatures"
+              "path": "nsg:neuriteFeature",
+              "name": "Neurite features",
+              "description": "Unopinionated metrics relative to the neurites of this morphology",
+              "node": "this:NeuriteFeature"
             }
           ]
         }
       ]
     },
-
-
-
     {
-      "@id": "this:NeuriteFeatures",
+      "@id": "this:NeuriteFeature",
       "@type": "sh:NodeShape",
       "property": [
         {
-          "path": "nsg:number",
-          "name": "Number",
-          "description": "The number of elements",
-          "datatype": "xsd:int",
-          "minCount": 0,
+          "path": "rdf:type",
+          "name": "Type",
+          "description": "The neurite type",
+          "in": [
+            "nsg:Axon",
+            "nsg:Dendrite",
+            "nsg:BasalDendrite",
+            "nsg:ApicalDendrite"
+          ],
+          "nodeKind": "sh:IRI",
           "maxCount": 1
         },
-
         {
-          "path": "nsg:cumulatedlength",
+          "path": "schema:size",
+          "name": "Size",
+          "description": "The size (number) of elements",
+          "datatype": "xsd:int",
+          "maxCount": 1
+        },
+        {
+          "path": "nsg:cumulatedLength",
           "name": "Cumulated length",
           "description": "Total length of a neurite category",
           "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape",
-          "minCount": 0,
           "maxCount": 1
         },
-
         {
           "path": "nsg:traversedBrainRegion",
-          "name": "Traversed brain region",
+          "name": "Traversed brain regions",
           "description": "Brain regions being traversed by all the neurites of this category",
-          "node": "nsg:ParcellationOntology",
-          "minCount": 0,
+          "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
           "maxCount": 1
         },
-
         {
           "path": "nsg:projectionBrainRegion",
-          "name": "Projection region",
+          "name": "Projection brain regions",
           "description": "Brain regions where all the neurites of this category have their projection (end)",
-          "node": "nsg:ParcellationOntology",
-          "minCount": 0,
+          "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
           "maxCount": 1
         }
-        
       ]
     }
-
-
-
   ]
 }

--- a/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
+++ b/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
@@ -11,7 +11,8 @@
     "https://neuroshapes.org/core/dataset",
     "https://neuroshapes.org/commons/quantitativevalue",
     "https://neuroshapes.org/commons/brainlocation",
-    "https://neuroshapes.org/commons/typedlabeledontologyterm"
+    "https://neuroshapes.org/commons/typedlabeledontologyterm",
+    "https://neuroshapes.org/commons/collection"
   ],
   "shapes": [
     {
@@ -28,11 +29,6 @@
         },
         {
           "property": [
-            {
-              "path": "nsg:isRegisteredIn",
-              "class": "nsg:BrainAtlasSpatialReferenceSystem",
-              "maxCount": 1
-            },
             {
               "path": "nsg:somaNumberOfPoints",
               "name": "Soma number of points",
@@ -53,47 +49,45 @@
     {
       "@id": "this:NeuriteFeature",
       "@type": "sh:NodeShape",
-      "property": [
+      "and": [
         {
-          "path": "rdf:type",
-          "name": "Type",
-          "description": "The neurite type",
-          "in": [
-            "nsg:Axon",
-            "nsg:Dendrite",
-            "nsg:BasalDendrite",
-            "nsg:ApicalDendrite"
-          ],
-          "nodeKind": "sh:IRI",
-          "maxCount": 1
+          "node": "https://neuroshapes.org/commons/collection/shapes/CollectionShape"
         },
         {
-          "path": "schema:size",
-          "name": "Size",
-          "description": "The size (number) of elements",
-          "datatype": "xsd:int",
-          "maxCount": 1
-        },
-        {
-          "path": "nsg:cumulatedLength",
-          "name": "Cumulated length",
-          "description": "Total length of a neurite category",
-          "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape",
-          "maxCount": 1
-        },
-        {
-          "path": "nsg:traversedBrainRegion",
-          "name": "Traversed brain regions",
-          "description": "Brain regions being traversed by all the neurites of this category",
-          "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
-          "maxCount": 1
-        },
-        {
-          "path": "nsg:projectionBrainRegion",
-          "name": "Projection brain regions",
-          "description": "Brain regions where all the neurites of this category have their projection (end)",
-          "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
-          "maxCount": 1
+        "property": [
+          {
+            "path": "rdf:type",
+            "name": "Type",
+            "description": "The neurite type",
+            "in": [
+              "nsg:Axon",
+              "nsg:Dendrite",
+              "nsg:BasalDendrite",
+              "nsg:ApicalDendrite"
+            ],
+            "nodeKind": "sh:IRI",
+            "minCount": 1
+          },
+          {
+            "path": "nsg:cumulatedLength",
+            "name": "Cumulated length",
+            "description": "Total length of a neurite category",
+            "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape",
+            "maxCount": 1
+          },
+          {
+            "path": "nsg:traversedBrainRegion",
+            "name": "Traversed brain regions",
+            "description": "Brain regions being traversed by neurites of this category",
+            "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
+          },
+          {
+            "path": "nsg:projectionBrainRegion",
+            "name": "Projection brain regions",
+            "description": "Brain regions where neurites of this category have their projection (i.e. where they terminate)",
+            "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
+          }
+        ]
         }
       ]
     }

--- a/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
+++ b/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
@@ -8,7 +8,7 @@
   "@id": "https://neuroshapes.org/dash/neuronmorphology",
   "@type": "nxv:Schema",
   "imports": [
-    "https://neuroshapes.org/core/dataset",
+    "https://neuroshapes.org/commons/minds",
     "https://neuroshapes.org/commons/quantitativevalue",
     "https://neuroshapes.org/commons/brainlocation",
     "https://neuroshapes.org/commons/typedlabeledontologyterm",
@@ -25,7 +25,7 @@
       "nodeKind": "sh:BlankNodeOrIRI",
       "and": [
         {
-          "node": "https://neuroshapes.org/core/dataset/shapes/DatasetShape"
+          "node": "https://neuroshapes.org/commons/minds/shapes/MINDSShape"
         },
         {
           "property": [

--- a/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
+++ b/shapes/neurosciencegraph/datashapes/morphology/neuronmorphology/schema.json
@@ -79,13 +79,13 @@
             "path": "nsg:traversedBrainRegion",
             "name": "Traversed brain regions",
             "description": "Brain regions being traversed by neurites of this category",
-            "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
+            "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape"
           },
           {
             "path": "nsg:projectionBrainRegion",
             "name": "Projection brain regions",
             "description": "Brain regions where neurites of this category have their projection (i.e. where they terminate)",
-            "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape",
+            "node": "https://neuroshapes.org/commons/typedlabeledontologyterm/shapes/BrainRegionOntologyTermShape"
           }
         ]
         }


### PR DESCRIPTION
Implemented changes agreed on 2020-11-02 on neuron morphology schema draft from @jonathanlurie 

- Removed the scale / morphologyOrigin property -> This information will be captured with the help of the type system; new types have already been added to the core ontology during the meeting
- Renamed nsg:count to schema:size property
- Collapsed the property shapes for apical dendrite, basal dendrite and axon into nsg:neuriteFeature property shape
- Added type property shape on the NeuriteFeatureShape (the type can be one of the following: `nsg:Axon` `nsg:Dendrite` `nsg:BasalDendrite` `nsg:ApicalDendrite`)
